### PR TITLE
filter_estreamauth: Move and rename filter class for MDL-82427

### DIFF
--- a/classes/text_filter.php
+++ b/classes/text_filter.php
@@ -21,9 +21,10 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  *
  */
-// require_once('../../config.php');
-defined('MOODLE_INTERNAL') || die();
-class filter_estreamauth extends moodle_text_filter {
+
+namespace filter_estreamauth;
+
+class text_filter extends \moodle_text_filter {
 
     private function userobfuscate($strx) {
 


### PR DESCRIPTION
This is necessary to avoid a bunch of page breaking debug messages in Moodle 4.5